### PR TITLE
chore: Fix ScanRepository

### DIFF
--- a/features/scan-data/src/main/java/it/ipzs/scan_data/ScanRepository.kt
+++ b/features/scan-data/src/main/java/it/ipzs/scan_data/ScanRepository.kt
@@ -56,6 +56,14 @@ class ScanRepository @Inject constructor(
                         TransferStatus.DISCONNECTED -> {
                             if (!transferManager.hasDocuments())
                                 onError()
+                            else {
+                                val result = transferManager.parseResult()
+                                lastDriveLicenseScanned = result
+                                if(lastDriveLicenseScanned != null){
+                                    transferManager.stopVerification(true, true)
+                                    onDocumentReceived()
+                                }
+                            }
                         }
                         TransferStatus.ERROR -> {
 


### PR DESCRIPTION
This PR fix a problem during presentation of single document. In particular if the `TransferStatus` is disconnected, the document received need to be processed.